### PR TITLE
Fixed get_token_from_service/1

### DIFF
--- a/lib/token_manager.ex
+++ b/lib/token_manager.ex
@@ -121,7 +121,7 @@ defmodule ExMicrosoftBot.TokenManager do
       )
 
     auth_api_endpoint
-    |> HTTPotion.post(body: Poison.encode!(body))
+    |> HTTPotion.post(body: body)
     |> Client.deserialize_response(&Poison.decode!(&1, as: %{}))
   end
 


### PR DESCRIPTION
This PR fixes a bug with `get_token_from_service/1` that couldn't retrieve tokens from https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token

`[error] Error response: 400: {"error":"invalid_scope","error_description":"AADSTS70011: The provided request must include a 'scope' input parameter. The provided value for the input parameter 'scope' is not valid. The scope https://api.botframework.com/.default\" is not valid.","error_codes":[70011], ...}`